### PR TITLE
Make `clear()` method cross platform.

### DIFF
--- a/bot/helpers.py
+++ b/bot/helpers.py
@@ -19,7 +19,10 @@ linebreak = "\n"
 # Clearing console
 # ==================================================
 def clear():
-    return os.system("cls")
+    if os.name == "nt":
+        return os.system("cls")
+    else:
+        return os.system("clear")
 
 
 # ==================================================


### PR DESCRIPTION
Closes #2
Should work (except on DOS or *really* old windows versions).

This implementation just checks if `os.name` is `"nt"` or not.